### PR TITLE
cupid: rro_overlays: Redo cutout overlays

### DIFF
--- a/rro_overlays/FrameworksResCupid/res/values/config.xml
+++ b/rro_overlays/FrameworksResCupid/res/values/config.xml
@@ -28,7 +28,20 @@
 
          @see https://www.w3.org/TR/SVG/paths.html#PathData
          -->
-    <string name="config_mainBuiltInDisplayCutout" translatable="false">M 0,0 H -33 V 87 H 33 V 0 H 0 Z</string>
+    <string name="config_mainBuiltInDisplayCutout" translatable="false">M -33 52 a 33 33 0 1 0 66 0 a 33 33 0 1 0 -66 0 Z</string>
+
+    <!--Like config_mainBuiltInDisplayCutout, but this path is used to report the
+        one single bounding rect per device edge to the app via
+        {@link DisplayCutout#getBoundingRect}. Note that this path should try to match the visual
+        appearance of the cutout as much as possible, and may be smaller than
+        config_mainBuiltInDisplayCutout
+        -->
+    <string name="config_mainBuiltInDisplayCutoutRectApproximation">M 0,0 H -33 V 87 H 33 V 0 H 0 Z</string>
+
+    <!--Whether the display cutout region of the main built-in display should be forced to
+        black in software (to avoid aliasing or emulate a cutout that is not physically existent).
+        -->
+    <bool name="config_fillMainBuiltInDisplayCutout">true</bool>
 
     <!-- The default refresh rate for a given device. Change this value to set a higher default
          refresh rate. If the hardware composer on the device supports display modes with a higher


### PR DESCRIPTION
This fixes pixel artifacts around the camera cutout caused by aliasing.